### PR TITLE
Add type parameter to key request callback

### DIFF
--- a/examples/publisher.c
+++ b/examples/publisher.c
@@ -58,9 +58,13 @@ static uint8_t keyData[NUM_KEYS][16] = {
     { 0x39,0x12,0x3e,0x7f,0x21,0xbc,0xa3,0x26,0x4e,0x6f,0x3a,0x21,0xa4,0xf1,0xb5,0x98 }
 };
 
-DPS_Status GetKey(DPS_Node* node, const DPS_UUID* kid, uint8_t* key, size_t keyLen)
+DPS_Status GetKey(DPS_Node* node, DPS_KeyType type, const DPS_UUID* kid, uint8_t* key, size_t keyLen)
 {
     size_t i;
+
+    if (type != DPS_KEY_PUBLICATION) {
+        return DPS_ERR_MISSING;
+    }
 
     for (i = 0; i < NUM_KEYS; ++i) {
         if (keyLen == 16 && DPS_UUIDCompare(kid, &keyId[i]) == 0) {

--- a/examples/reg_pubs.c
+++ b/examples/reg_pubs.c
@@ -59,9 +59,13 @@ static uint8_t keyData[NUM_KEYS][16] = {
     { 0x39,0x12,0x3e,0x7f,0x21,0xbc,0xa3,0x26,0x4e,0x6f,0x3a,0x21,0xa4,0xf1,0xb5,0x98 }
 };
 
-DPS_Status GetKey(DPS_Node* node, const DPS_UUID* kid, uint8_t* key, size_t keyLen)
+DPS_Status GetKey(DPS_Node* node, DPS_KeyType type, const DPS_UUID* kid, uint8_t* key, size_t keyLen)
 {
     size_t i;
+
+    if (type != DPS_KEY_PUBLICATION) {
+        return DPS_ERR_MISSING;
+    }
 
     for (i = 0; i < NUM_KEYS; ++i) {
         if (DPS_UUIDCompare(kid, &keyId[i]) == 0) {

--- a/examples/reg_subs.c
+++ b/examples/reg_subs.c
@@ -27,9 +27,13 @@ static uint8_t keyData[NUM_KEYS][16] = {
     { 0x39,0x12,0x3e,0x7f,0x21,0xbc,0xa3,0x26,0x4e,0x6f,0x3a,0x21,0xa4,0xf1,0xb5,0x98 }
 };
 
-DPS_Status GetKey(DPS_Node* node, const DPS_UUID* kid, uint8_t* key, size_t keyLen)
+DPS_Status GetKey(DPS_Node* node, DPS_KeyType type, const DPS_UUID* kid, uint8_t* key, size_t keyLen)
 {
     size_t i;
+
+    if (type != DPS_KEY_PUBLICATION) {
+        return DPS_ERR_MISSING;
+    }
 
     for (i = 0; i < NUM_KEYS; ++i) {
         if (DPS_UUIDCompare(kid, &keyId[i]) == 0) {

--- a/examples/subscriber.c
+++ b/examples/subscriber.c
@@ -48,9 +48,13 @@ static uint8_t keyData[NUM_KEYS][16] = {
     { 0x39,0x12,0x3e,0x7f,0x21,0xbc,0xa3,0x26,0x4e,0x6f,0x3a,0x21,0xa4,0xf1,0xb5,0x98 }
 };
 
-DPS_Status GetKey(DPS_Node* node, const DPS_UUID* kid, uint8_t* key, size_t keyLen)
+DPS_Status GetKey(DPS_Node* node, DPS_KeyType type, const DPS_UUID* kid, uint8_t* key, size_t keyLen)
 {
     size_t i;
+
+    if (type != DPS_KEY_PUBLICATION) {
+        return DPS_ERR_MISSING;
+    }
 
     for (i = 0; i < NUM_KEYS; ++i) {
         if (keyLen == 16 && DPS_UUIDCompare(kid, &keyId[i]) == 0) {

--- a/inc/dps/dps.h
+++ b/inc/dps/dps.h
@@ -45,6 +45,11 @@ extern "C" {
 #define DPS_MCAST_PUB_ENABLE_SEND    1
 #define DPS_MCAST_PUB_ENABLE_RECV    2
 
+typedef enum {
+    DPS_KEY_PUBLICATION,
+    DPS_KEY_DTLS_SHARED_KEY,
+} DPS_KeyType;
+
 
 /**
  * Opaque type for a node
@@ -137,6 +142,7 @@ DPS_Node* DPS_PublicationGetNode(const DPS_Publication* pub);
  * for a specific key identifier. This function must not block
  *
  * @param node    The node that is requesting the key
+ * @param type    The type of key requested, e.g. publication, pre-shared key of DTLS.
  * @param kid     The key identifier
  * @param key     Buffer for returning the key.
  * @param keyLen  Size of the key buffer
@@ -144,7 +150,7 @@ DPS_Node* DPS_PublicationGetNode(const DPS_Publication* pub);
  * @return  DPS_OK if a key matching the kid was returned
  *          DPS_ERR_MSSING if there is no matching key
  */
-typedef DPS_Status (*DPS_KeyRequestCallback)(DPS_Node* node, const DPS_UUID* kid, uint8_t* key, size_t keyLen);
+typedef DPS_Status (*DPS_KeyRequestCallback)(DPS_Node* node, DPS_KeyType type, const DPS_UUID* kid, uint8_t* key, size_t keyLen);
 
 /**
  * Allocates space for a local DPS node.

--- a/src/ack.c
+++ b/src/ack.c
@@ -87,7 +87,7 @@ static DPS_Status GetKey(void* ctx, const DPS_UUID* kid, int8_t alg, uint8_t key
     DPS_Node* node = (DPS_Node*)ctx;
 
     if (node->keyRequestCB) {
-        return node->keyRequestCB(node, kid, key, AES_128_KEY_LEN);
+        return node->keyRequestCB(node, DPS_KEY_PUBLICATION, kid, key, AES_128_KEY_LEN);
     } else {
         return DPS_ERR_MISSING;
     }

--- a/src/pub.c
+++ b/src/pub.c
@@ -189,7 +189,7 @@ static DPS_Status GetKey(void* ctx, const DPS_UUID* kid, int8_t alg, uint8_t key
     DPS_Node* node = (DPS_Node*)ctx;
 
     if (node->keyRequestCB) {
-        return node->keyRequestCB(node, kid, key, AES_128_KEY_LEN);
+        return node->keyRequestCB(node, DPS_KEY_PUBLICATION, kid, key, AES_128_KEY_LEN);
     } else {
         return DPS_ERR_MISSING;
     }


### PR DESCRIPTION
Currently we have only one type of key, to be used with COSE for the
content of publications. When supporting DTLS, there will be the need
of different types of keys.

NOTE: This patch contains an API change.