### PR TITLE
Fix stale criteria for publications

### DIFF
--- a/src/pub.c
+++ b/src/pub.c
@@ -500,7 +500,7 @@ DPS_Status DPS_DecodePublication(DPS_Node* node, DPS_NetEndpoint* ep, DPS_RxBuff
         /*
          * Retained publications can only be updated with newer revisions
          */
-        if (sequenceNum < pub->sequenceNum) {
+        if (sequenceNum <= pub->sequenceNum) {
             DPS_ERRPRINT("Publication is stale");
             return DPS_ERR_STALE;
         }


### PR DESCRIPTION
A publication is stale if it is not newer. The same sequence number
means a stale publication.

This fixes the case of a publisher that sends and receives
multicast. The code would proceed and end up removing the publication
from the list, a subsequent publish with the same publication would
fail.