### PR TITLE
Add script to run and verify the existing test apps and scripts.

### DIFF
--- a/dps_shared.def
+++ b/dps_shared.def
@@ -33,6 +33,7 @@ DPS_Rand
 DPS_ResolveAddress
 DPS_SetAddress
 DPS_SetNodeData
+DPS_SetNodeSubscriptionUpdateDelay
 DPS_SetPublicationData
 DPS_SetSubscriptionData
 DPS_StartNode

--- a/examples/publisher.c
+++ b/examples/publisher.c
@@ -236,6 +236,7 @@ int main(int argc, char** argv)
     int wait = 0;
     int encrypt = DPS_TRUE;
     int ttl = 0;
+    int subsRate = DPS_SUBSCRIPTION_UPDATE_RATE;
     int i;
     char* msg = NULL;
     int mcast = DPS_MCAST_PUB_ENABLE_SEND;
@@ -273,6 +274,9 @@ int main(int argc, char** argv)
             continue;
         }
         if (IntArg("-t", &arg, &argc, &ttl, 0, 2000)) {
+            continue;
+        }
+        if (IntArg("-r", &arg, &argc, &subsRate, 0, INT32_MAX)) {
             continue;
         }
         if (IntArg("-x", &arg, &argc, &encrypt, 0, 1)) {
@@ -315,6 +319,7 @@ int main(int argc, char** argv)
     }
 
     node = DPS_CreateNode("/.", DPS_MemoryKeyStoreHandle(memoryKeyStore), nodeKeyId);
+    DPS_SetNodeSubscriptionUpdateDelay(node, subsRate);
 
     ret = DPS_StartNode(node, mcast, listenPort);
     if (ret != DPS_OK) {
@@ -377,7 +382,7 @@ int main(int argc, char** argv)
     return 0;
 
 Usage:
-    DPS_PRINT("Usage %s [-d] [-x 0/1] [-a] [-w <seconds>] <seconds>] [-t <ttl>] [[-h <hostname>] -p <portnum>] [-l <portnum>] [-m <message>] [topic1 topic2 ... topicN]\n", argv[0]);
+    DPS_PRINT("Usage %s [-d] [-x 0/1] [-a] [-w <seconds>] <seconds>] [-t <ttl>] [[-h <hostname>] -p <portnum>] [-l <portnum>] [-m <message>] [-r <milliseconds>] [topic1 topic2 ... topicN]\n", argv[0]);
     DPS_PRINT("       -d: Enable debug ouput if built for debug.\n");
     DPS_PRINT("       -x: Enable or disable encryption. Default is encryption enabled.\n");
     DPS_PRINT("       -a: Request an acknowledgement\n");
@@ -387,6 +392,7 @@ Usage:
     DPS_PRINT("       -h: Specifies host (localhost is default). Mutiple -h options are permitted.\n");
     DPS_PRINT("       -p: port to link. Multiple -p options are permitted.\n");
     DPS_PRINT("       -m: A payload message to accompany the publication.\n\n");
+    DPS_PRINT("       -r: Time to delay between subscription updates.\n\n");
     DPS_PRINT("           Enters interactive mode if there are no topic strings on the command line.\n");
     DPS_PRINT("           In interactive mode type -h for commands.\n");
     return 1;

--- a/examples/subscriber.c
+++ b/examples/subscriber.c
@@ -140,6 +140,7 @@ int main(int argc, char** argv)
     int mcastPub = DPS_MCAST_PUB_DISABLED;
     const char* host = NULL;
     int encrypt = DPS_TRUE;
+    int subsRate = DPS_SUBSCRIPTION_UPDATE_RATE;
     int listenPort = 0;
     int numLinks = 0;
     int linkPort[MAX_LINKS];
@@ -181,6 +182,9 @@ int main(int argc, char** argv)
                 continue;
             }
             if (IntArg("-x", &arg, &argc, &encrypt, 0, 1)) {
+                continue;
+            }
+            if (IntArg("-r", &arg, &argc, &subsRate, 0, INT32_MAX)) {
                 continue;
             }
             if (strcmp(*arg, "-m") == 0) {
@@ -226,6 +230,7 @@ int main(int argc, char** argv)
         DPS_SetNetworkKey(memoryKeyStore, "test", 4);
     }
     node = DPS_CreateNode("/.", DPS_MemoryKeyStoreHandle(memoryKeyStore), nodeKeyId);
+    DPS_SetNodeSubscriptionUpdateDelay(node, subsRate);
 
     ret = DPS_StartNode(node, mcastPub, listenPort);
     if (ret != DPS_OK) {
@@ -289,7 +294,7 @@ int main(int argc, char** argv)
     return 0;
 
 Usage:
-    DPS_PRINT("Usage %s [-d] [-q] [-m] [-w <seconds>] [-x 0/1] [[-h <hostname>] -p <portnum>] [-l <listen port] [-m] [-d] [[-s] topic1 ... topicN]\n", argv[0]);
+    DPS_PRINT("Usage %s [-d] [-q] [-m] [-w <seconds>] [-x 0/1] [[-h <hostname>] -p <portnum>] [-l <listen port] [-m] [-d] [-r <milliseconds>] [[-s] topic1 ... topicN]\n", argv[0]);
     DPS_PRINT("       -d: Enable debug ouput if built for debug.\n");
     DPS_PRINT("       -q: Quiet - suppresses output about received publications.\n");
     DPS_PRINT("       -x: Enable or disable encryption. Default is encryption enabled.\n");
@@ -298,6 +303,7 @@ Usage:
     DPS_PRINT("       -p: A port to link. Multiple -p options are permitted.\n");
     DPS_PRINT("       -m: Enable multicast receive. Enabled by default is there are no -p options.\n");
     DPS_PRINT("       -l: port to listen on. Default is an ephemeral port.\n");
+    DPS_PRINT("       -r: Time to delay between subscription updates.\n\n");
     DPS_PRINT("       -s: list of subscription topic strings. Multiple -s options are permitted\n");
     return 1;
 }

--- a/inc/dps/dps.h
+++ b/inc/dps/dps.h
@@ -230,6 +230,19 @@ typedef void (*DPS_OnNodeDestroyed)(DPS_Node* node, void* data);
 DPS_Status DPS_DestroyNode(DPS_Node* node, DPS_OnNodeDestroyed cb, void* data);
 
 /**
+ * The default maximum rate (in msecs) to compute and send out subscription updates.
+ */
+#define DPS_SUBSCRIPTION_UPDATE_RATE 1000
+
+/**
+ * Specify the time delay (in msecs) between subscription updates.
+ *
+ * @param node           The node
+ * @param subsRateMsecs  The time delay (in msecs) between updates
+ */
+void DPS_SetNodeSubscriptionUpdateDelay(DPS_Node* node, uint32_t subsRateMsecs);
+
+/**
  * Get the uv event loop for this node. The only thing that is safe to do with the node
  * is to create an async callback. Other libuv APIs can then be called from within the
  * async callback.

--- a/src/dps.c
+++ b/src/dps.c
@@ -756,13 +756,6 @@ static void SendPubsTask(uv_async_t* handle)
     DPS_UnlockNode(node);
 }
 
-/*
- * Maximum rate in msecs to compute and send out subscription updates
- *
- * TODO - this value needs to be tuned
- */
-#define SUBSCRIPTION_UPDATE_RATE 1000
-
 static void SendSubsTimer(uv_timer_t* handle)
 {
     DPS_Node* node = (DPS_Node*)handle->data;
@@ -1208,7 +1201,7 @@ DPS_Node* DPS_CreateNode(const char* separators, DPS_KeyStore* keyStore, const D
      * Set default probe configuration and subscription rate parameters
      */
     node->linkMonitorConfig = LinkMonitorConfigDefaults;
-    node->subsRate = SUBSCRIPTION_UPDATE_RATE;
+    node->subsRate = DPS_SUBSCRIPTION_UPDATE_RATE;
     return node;
 }
 
@@ -1395,6 +1388,11 @@ DPS_Status DPS_DestroyNode(DPS_Node* node, DPS_OnNodeDestroyed cb, void* data)
     }
     free(node);
     return DPS_ERR_NODE_DESTROYED;
+}
+
+void DPS_SetNodeSubscriptionUpdateDelay(DPS_Node* node, uint32_t subsRateMsecs)
+{
+    node->subsRate = subsRateMsecs;
 }
 
 DPS_Status DPS_Link(DPS_Node* node, DPS_NodeAddress* addr, DPS_OnLinkComplete cb, void* data)

--- a/test/cbortest.c
+++ b/test/cbortest.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
+#include "test.h"
 #include <dps/private/cbor.h>
 
 static uint8_t buf[1 << 19];
@@ -128,7 +128,7 @@ int main(int argc, char** argv)
     DPS_TxBufferToRx(&txBuffer, &rxBuffer);
 
     ret = CBOR_DecodeArray(&rxBuffer, &size);
-    assert(size == 41);
+    ASSERT(size == 41);
     CHECK(ret);
 
     /*
@@ -137,35 +137,35 @@ int main(int argc, char** argv)
     for (i = 0; i < sizeof(Uints) / sizeof(Uints[0]); ++i) {
         uint64_t n;
         ret = CBOR_DecodeUint(&rxBuffer, &n);
-        assert(n == Uints[i]);
+        ASSERT(n == Uints[i]);
         CHECK(ret);
     }
 
     CBOR_DecodeBytes(&rxBuffer, &test, &i);
-    assert(i == sizeof(Uints));
-    assert(memcmp(Uints, test, i) == 0);
+    ASSERT(i == sizeof(Uints));
+    ASSERT(memcmp(Uints, test, i) == 0);
 
     for (i = 0; i < sizeof(Sints) / sizeof(Sints[0]); ++i) {
         int64_t n;
         ret = CBOR_DecodeInt(&rxBuffer, &n);
-        assert(n == Sints[i]);
+        ASSERT(n == Sints[i]);
         CHECK(ret);
     }
 
     ret = CBOR_DecodeArray(&rxBuffer, &size);
-    assert(size == (sizeof(Strings) / sizeof(Strings[0])));
+    ASSERT(size == (sizeof(Strings) / sizeof(Strings[0])));
     CHECK(ret);
 
     for (i = 0; i < sizeof(Strings) / sizeof(Strings[0]); ++i) {
         char *str;
         size_t len;
         ret = CBOR_DecodeString(&rxBuffer, &str, &len);
-        assert(!strcmp(str, Strings[i]));
+        ASSERT(strlen(Strings[i]) == len && !strncmp(str, Strings[i], len));
         CHECK(ret);
     }
 
     ret = CBOR_DecodeMap(&rxBuffer, &size);
-    assert(size == (sizeof(Maps) / sizeof(Maps[0])));
+    ASSERT(size == (sizeof(Maps) / sizeof(Maps[0])));
     CHECK(ret);
 
     for (i = 0; i < sizeof(Maps) / sizeof(Maps[0]); ++i) {
@@ -174,10 +174,10 @@ int main(int argc, char** argv)
         size_t len;
         ret = CBOR_DecodeUint(&rxBuffer, &n);
         CHECK(ret);
-        assert(n == Maps[i].key);
+        ASSERT(n == Maps[i].key);
         ret = CBOR_DecodeString(&rxBuffer, &str, &len);
         CHECK(ret);
-        assert(!strcmp(str, Maps[i].string));
+        ASSERT(strlen(Maps[i].string) == len && !strncmp(str, Maps[i].string, len));
     }
 
     CBOR_MapState map;
@@ -198,7 +198,7 @@ int main(int argc, char** argv)
             CHECK(ret);
             break;
         default:
-            assert(0);
+            ASSERT(0);
             break;
         }
     }
@@ -206,7 +206,7 @@ int main(int argc, char** argv)
     for (i = 0; i < sizeof(Tags) / sizeof(Tags[0]); ++i) {
         int64_t n;
         ret = CBOR_DecodeTag(&rxBuffer, &n);
-        assert(n == Tags[i]);
+        ASSERT(n == Tags[i]);
         CHECK(ret);
     }
 
@@ -215,7 +215,7 @@ int main(int argc, char** argv)
      */
     ret = CBOR_DecodeArray(&rxBuffer, &size);
     CHECK(ret);
-    assert(size == 41);
+    ASSERT(size == 41);
 
     for (n = 0; n < 41; ++n) {
         size_t sz;
@@ -273,20 +273,20 @@ int main(int argc, char** argv)
         CHECK(ret);
         DPS_TxBufferToRx(&txBuffer, &rxBuffer);
         ret = CBOR_DecodeBytes(&rxBuffer, &data, &size);
-        assert(!DPS_RxBufferAvail(&rxBuffer));
+        ASSERT(!DPS_RxBufferAvail(&rxBuffer));
         CHECK(ret);
         DPS_RxBufferInit(&rxInner, data, size);
         ret = CBOR_DecodeString(&rxInner, &str, &size);
-        assert(!DPS_RxBufferAvail(&rxInner));
-        assert(strcmp(str, testString) == 0);
+        ASSERT(!DPS_RxBufferAvail(&rxInner));
+        ASSERT(strlen(testString) == size && strncmp(str, testString, size) == 0);
         CHECK(ret);
     }
 
     printf("Passed\n");
-    return 0;
+    return EXIT_SUCCESS;
 
 Failed:
 
     printf("Failed at line %d %s\n", ln, DPS_ErrTxt(ret));
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/cosetest.c
+++ b/test/cosetest.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
+#include "test.h"
 #include <dps/dbg.h>
 #include <dps/err.h>
 #include <dps/private/dps.h>
@@ -81,7 +81,7 @@ uint8_t config[] = {
 static DPS_Status GetKey(void* ctx, const DPS_UUID* kid, int8_t alg, uint8_t* k)
 {
     if (DPS_UUIDCompare(kid, &keyId) != 0) {
-        assert(0);
+        ASSERT(0);
         return DPS_ERR_MISSING;
     } else {
         memcpy(k, key, sizeof(key));
@@ -99,12 +99,12 @@ static void CCM_Raw()
     DPS_TxBufferInit(&plainText, NULL, 512);
 
     ret = Encrypt_CCM(key, 16, 2, nonce, (uint8_t*)msg, sizeof(msg), aad, sizeof(aad), &cipherText);
-    assert(ret == DPS_OK);
+    ASSERT(ret == DPS_OK);
     ret = Decrypt_CCM(key, 16, 2, nonce, cipherText.base, DPS_TxBufferUsed(&cipherText), aad, sizeof(aad), &plainText);
-    assert(ret == DPS_OK);
+    ASSERT(ret == DPS_OK);
 
-    assert(DPS_TxBufferUsed(&plainText) == sizeof(msg));
-    assert(memcmp(plainText.base, msg, sizeof(msg)) == 0);
+    ASSERT(DPS_TxBufferUsed(&plainText) == sizeof(msg));
+    ASSERT(memcmp(plainText.base, msg, sizeof(msg)) == 0);
 
     DPS_TxBufferFree(&cipherText);
     DPS_TxBufferFree(&plainText);
@@ -134,7 +134,7 @@ int main(int argc, char** argv)
         ret = COSE_Encrypt(alg, &keyId, nonce, &aadBuf, &msgBuf, GetKey, NULL, &cipherText);
         if (ret != DPS_OK) {
             DPS_ERRPRINT("COSE_Encrypt failed: %s\n", DPS_ErrTxt(ret));
-            return 1;
+            return EXIT_FAILURE;
         }
         Dump("CipherText", cipherText.base, DPS_TxBufferUsed(&cipherText));
         /*
@@ -147,16 +147,16 @@ int main(int argc, char** argv)
         ret = COSE_Decrypt(nonce, &kid, &aadBuf, &input, GetKey, NULL, &plainText);
         if (ret != DPS_OK) {
             DPS_ERRPRINT("COSE_Decrypt failed: %s\n", DPS_ErrTxt(ret));
-            return 1;
+            return EXIT_FAILURE;
         }
 
-        assert(DPS_TxBufferUsed(&plainText) == sizeof(msg));
-        assert(memcmp(plainText.base, msg, sizeof(msg)) == 0);
+        ASSERT(DPS_TxBufferUsed(&plainText) == sizeof(msg));
+        ASSERT(memcmp(plainText.base, msg, sizeof(msg)) == 0);
 
         DPS_TxBufferFree(&cipherText);
         DPS_TxBufferFree(&plainText);
     }
 
     DPS_PRINT("Passed\n");
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/test/countvec.c
+++ b/test/countvec.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <dps/dbg.h>
 #include "bitvec.h"
+#include "test.h"
 
 #define BITLEN  64
 
@@ -35,9 +36,7 @@ static void SetBits(DPS_BitVector* bv, uint8_t n)
 
     memset(buf, n, sizeof(buf));
     ret = DPS_BitVectorSet(bv, buf, sizeof(buf));
-    if (ret != DPS_OK) {
-        DPS_PRINT("DPS_BitVectorSet returned %s\n", DPS_ErrTxt(ret));
-    }
+    ASSERT(ret == DPS_OK);
 }
 
 static void TestAdd(DPS_CountVector* cv, uint8_t n)
@@ -105,5 +104,5 @@ int main(int argc, char** argv)
     TestAdd(cv, 0x01);
     TestAdd(cv, 0x03);
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/test/hist_unit.c
+++ b/test/hist_unit.c
@@ -25,7 +25,6 @@
  *
  */
 #include <memory.h>
-#include <assert.h>
 #include <stdlib.h>
 #include <uv.h>
 #include <dps/dps.h>
@@ -63,7 +62,7 @@ int main()
     ret = DPS_InitUUID();
     if (ret != DPS_OK) {
         DPS_PRINT("DPS_InitUUID failed\n");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     history.loop = uv_default_loop();
@@ -99,7 +98,7 @@ int main()
     for (i = 0; i < NUM_PUBS; ++i) {
         if (DPS_LookupPublisherForAck(&history, &uuid[i], &sn, &addrPtr) != DPS_OK) {
             DPS_PRINT("Pub history lookup failed\n");
-            return 1;
+            return EXIT_FAILURE;
         }
     }
     /*
@@ -109,7 +108,7 @@ int main()
     for (i = 0; i < NUM_PUBS / 4; ++i) {
         if (DPS_DeletePubHistory(&history, &uuid[i]) != DPS_OK) {
             DPS_PRINT("Pub history delete failed\n");
-            return 1;
+            return EXIT_FAILURE;
         }
     }
     /*
@@ -119,7 +118,7 @@ int main()
     for (i = NUM_PUBS / 4; i < NUM_PUBS; ++i) {
         if (DPS_LookupPublisherForAck(&history, &uuid[i], &sn, &addrPtr) != DPS_OK) {
             DPS_PRINT("Pub history lookup failed\n");
-            return 1;
+            return EXIT_FAILURE;
         }
     }
     /*
@@ -136,7 +135,7 @@ int main()
     for (i = 0; i < NUM_PUBS; ++i) {
         if (DPS_LookupPublisherForAck(&history, &uuid[i], &sn, &addrPtr) != DPS_OK) {
             DPS_PRINT("Pub history lookup failed\n");
-            return 1;
+            return EXIT_FAILURE;
         }
     }
     /*
@@ -162,12 +161,12 @@ int main()
         if (i >= NUM_PUBS / 4 &&  i < NUM_PUBS / 3) {
             if (ret != DPS_OK) {
                 DPS_PRINT("Pub history is missing\n");
-                return 1;
+                return EXIT_FAILURE;
             }
         } else {
             if (ret != DPS_ERR_MISSING) {
                 DPS_PRINT("Pub history was not expired\n");
-                return 1;
+                return EXIT_FAILURE;
             }
         }
     }
@@ -175,6 +174,6 @@ int main()
 
     DPS_PRINT("Unit test passed\n");
 
-    return 0;
+    return EXIT_SUCCESS;
 
 }

--- a/test/make_mesh.c
+++ b/test/make_mesh.c
@@ -23,7 +23,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <assert.h>
 #include <uv.h>
 #include <dps/private/network.h>
 #include <dps/dbg.h>

--- a/test/mesh_stress.c
+++ b/test/mesh_stress.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <assert.h>
+#include "test.h"
 #include <uv.h>
 #include <dps/private/network.h>
 #include <dps/dbg.h>
@@ -402,19 +402,19 @@ int main(int argc, char** argv)
         }
         if (*arg[0] == '-') {
             DPS_PRINT("Unknown option %s\n", arg[0]);
-            return 1;
+            return EXIT_FAILURE;
         }
         inFn = *arg++;
     }
     if (inFn) {
         numIds = ReadLinks(inFn);
         if (numIds == 0) {
-            return 1;
+            return EXIT_FAILURE;
         }
         DumpLinks();
     } else {
         DPS_PRINT("No input file\n");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     /*
@@ -439,12 +439,12 @@ int main(int argc, char** argv)
             /*
              * For test purposes we only want a short subscription delay
              */
-            node->subsRate = 300;
+            DPS_SetNodeSubscriptionUpdateDelay(node, 300);
 
             ret = DPS_StartNode(node, DPS_FALSE, 0);
             if (ret != DPS_OK) {
                 DPS_ERRPRINT("Failed to start node: %s\n", DPS_ErrTxt(ret));
-                return 1;
+                return EXIT_FAILURE;
             }
             PortMap[DPS_GetPortNumber(node)] = NodeList[i];
             NodeMap[NodeList[i]] = node;
@@ -509,7 +509,7 @@ int main(int argc, char** argv)
                 break;
             }
             DPS_ERRPRINT("Subscribe failed %s\n", DPS_ErrTxt(ret));
-            return 1;
+            return EXIT_FAILURE;
         }
         /*
          * Check we got the result we expected
@@ -530,7 +530,7 @@ int main(int argc, char** argv)
 
         if (numMuted != expMuted) {
             DPS_ERRPRINT("Wrong number of muted nodes: Expected %d got %d\n", expMuted, numMuted);
-            assert(expMuted == numMuted);
+            ASSERT(expMuted == numMuted);
         }
 #ifndef NDEBUG
         {
@@ -553,5 +553,5 @@ int main(int argc, char** argv)
     }
     DPS_DestroyEvent(sleeper);
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/test/packtest.c
+++ b/test/packtest.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
+#include "test.h"
 #include <dps/dbg.h>
 #include "topics.h"
 
@@ -126,7 +126,7 @@ static DPS_Status InitBitVector(DPS_BitVector* bf, size_t len, int testCase)
         ret |= DPS_AddTopic(bf, "razz/baz/x=5", "/=", DPS_SubTopic);
         break;
     }
-    assert(ret == DPS_OK);
+    ASSERT(ret == DPS_OK);
     free(data);
     DPS_BitVectorDump(bf, 1);
     return ret;
@@ -149,7 +149,7 @@ static void RunTests(DPS_BitVector* pubBf, size_t size)
         InitBitVector(pubBf, size, i);
 
         ret = DPS_BitVectorSerialize(pubBf, &txBuf);
-        assert(ret == DPS_OK);
+        ASSERT(ret == DPS_OK);
         /*
          * Switch over from writing to reading
          */
@@ -157,12 +157,12 @@ static void RunTests(DPS_BitVector* pubBf, size_t size)
 
         bf = DPS_BitVectorAlloc();
         ret = DPS_BitVectorDeserialize(bf, &rxBuf);
-        assert(ret == DPS_OK);
+        ASSERT(ret == DPS_OK);
 
         DPS_BitVectorDump(bf, 1);
 
         cmp = DPS_BitVectorEquals(bf, pubBf);
-        assert(cmp == 1);
+        ASSERT(cmp == 1);
 
         DPS_BitVectorFree(bf);
         DPS_BitVectorClear(pubBf);
@@ -178,17 +178,17 @@ int main(int argc, char** argv)
 
     if (filterBits <= 0) {
         printf("Usage %s: <filter-bits> [<num-hashes>]\n", argv[0]);
-        exit(0);
+        return EXIT_FAILURE;
     }
 
     ret = DPS_Configure(filterBits, numHashes);
     if (ret != DPS_OK) {
         DPS_ERRPRINT("Invalid configuration parameters\n");
-        return 1;
+        return EXIT_FAILURE;
     }
 
     bf = DPS_BitVectorAlloc();
     RunTests(bf, filterBits / 8);
     DPS_BitVectorFree(bf);
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/test/pubsub.c
+++ b/test/pubsub.c
@@ -51,10 +51,12 @@ static void SubscriptionCheck(DPS_BitVector* pubFilter, const char* subscription
             printf("Matched expected (false positive) topic %s: PASS\n", subscription);
         } else {
             printf("Matched unexpected topic %s: FAIL\n", subscription);
+            exit(EXIT_FAILURE);
         }
     } else {
         if (expect == EXPECT) {
             printf("No match for expected topic %s: FAIL\n", subscription);
+            exit(EXIT_FAILURE);
         } else if (expect == EXPECT_FALSE_POSITIVE) {
             printf("No match for expected (false positive) topic %s: FAIL\n", subscription);
         } else {
@@ -132,7 +134,6 @@ int main(int argc, char** argv)
     AddTopic(pubFilter, "x/y/z");
     AddTopic(pubFilter, "a/b/z");
 
-
     //DPS_BitVectorDump(pubFilter, 1);
     SubscriptionCheck(pubFilter, "foo/+/+.#", EXPECT);
     SubscriptionCheck(pubFilter, "foo/+/+/+/#", NOT_EXPECT);
@@ -164,9 +165,9 @@ int main(int argc, char** argv)
     SubscriptionCheck(pubFilter, "x/b/#", NOT_EXPECT);
     SubscriptionCheck(pubFilter, "+.+.c.5", NOT_EXPECT);
 
-    return 0;
+    return EXIT_SUCCESS;
 
 Usage:
     DPS_PRINT("Usage %s: [-r] [-b <filter-bits>] [-n <num-hashes>]\n", argv[0]);
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/rle_compression.c
+++ b/test/rle_compression.c
@@ -102,10 +102,10 @@ int main(int argc, char** argv)
     DPS_PRINT("Added %d: ", (int)(i - base));
     DPS_BitVectorDump(bf, 0);
 
-    return 0;
+    return EXIT_SUCCESS;
 
 Usage:
 
     DPS_PRINT("Usage %s: [-d] [-b <filter-bits>] [-n <num-hashes>]\n", argv[0]);
-    return 1;
+    return EXIT_FAILURE;
 }

--- a/test/test.h
+++ b/test/test.h
@@ -1,0 +1,31 @@
+/*
+ *******************************************************************
+ *
+ * Copyright 2017 Intel Corporation All rights reserved.
+ *
+ *-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+
+#ifndef _TEST_H
+#define _TEST_H
+
+#include <assert.h>
+#include <stdlib.h>
+
+#define ASSERT(cond) do { assert(cond); if (!(cond)) exit(EXIT_FAILURE); } while (0)
+
+#endif

--- a/test/topic_match.c
+++ b/test/topic_match.c
@@ -120,7 +120,7 @@ int main(int argc, char** argv)
     ret = DPS_MatchTopicList(pubs, numPubs, subs, numSubs, separators, noWildCard, &match);
     if (ret != DPS_OK) {
         DPS_PRINT("Error: %s\n", DPS_ErrTxt(ret));
-        return 1;
+        return EXIT_FAILURE;
     }
     if (match) {
         DPS_PRINT("Match\n");
@@ -130,10 +130,9 @@ int main(int argc, char** argv)
     if (BloomMatch(pubs, numPubs, subs, numSubs, noWildCard) != match) {
         DPS_PRINT("FAILURE: Different bloom filter match\n");
     }
-    return 0;
+    return EXIT_SUCCESS;
 
 Usage:
     DPS_PRINT("Usage %s: [-d] -p <pub topics> -s <sub topics>\n", argv[0]);
-    return 1;
-
+    return EXIT_FAILURE;
 }

--- a/test_scripts/chain_test
+++ b/test_scripts/chain_test
@@ -18,4 +18,5 @@ pub 1.1 2.1 3.1 4.1
 
 sleep 2
 
-cleanup
+assert_no_errors
+expect_pubs_received 4 1.1 2.1 3.1 4.1

--- a/test_scripts/fanout
+++ b/test_scripts/fanout
@@ -5,8 +5,6 @@ dir="${BASH_SOURCE%/*}"
 if [[ ! -d "$dir" ]]; then dir="$PWD"; fi
 . "$dir/common.sh"
 
-cleanup
-
 sub -w 1 -l 40000 -s X -s A
 sub -w 1 -l 40001 -p 40000 -s X -s B
 sub -w 1 -l 40002 -p 40001 -s X -s C
@@ -19,7 +17,6 @@ sub -w 1 -l 40008 -p 40007 -s X -s I
 sub -w 1 -l 40009 -p 40008 -s X -s J
 sub -w 1 -l 40010 -p 40009 -s X -s K
 
-
 # Link to all nodes in chain
 
 sub -w 2 -l 40011 -p 40000 -p 40001 -p 40002 -p 40003 -p 40004 -p 40005 -p 40006 -p 40007 -p 40008 -p 40009 -p 40010 -s X -s L
@@ -27,9 +24,6 @@ sub -w 2 -l 39999 -p 40010 -p 40009 -p 40008 -p 40007 -p 40006 -p 40005 -p 40004
 sub -w 2 -l 40012 -p 40008 -p 40007 -p 40004 -p 40006 -p 40010 -p 40000 -p 40002 -p 40009 -p 40005 -p 40003 -p 40001 -s X -s N
 
 sleep 4
-
-echo "Errors"
-grep -r "ERROR" out | wc -l
 
 pub -p 39999 A B C D E F G H I J K L M N
 pub -p 40000 A B C D E F G H I J K L M N
@@ -48,9 +42,7 @@ pub -p 40012 A B C D E F G H I J K L M N
 
 sleep 1
 
-echo
-echo "Pubs received (expect 196)"
-grep "pub [A|B|C|D|E|F|G|H|I|J|K|L|M|N]" out/sub*.log | wc -l
+expect_pubs_received 196 A B C D E F G H I J K L M N
 
 # Reachability check
 
@@ -58,6 +50,5 @@ pub -p 40005 X
 
 sleep 1
 
-echo
-echo "Pubs received (expect 14)"
-grep "pub X" out/sub*.log | wc -l
+assert_no_errors
+expect_pubs_received 14 X

--- a/test_scripts/hot_mesh
+++ b/test_scripts/hot_mesh
@@ -5,8 +5,6 @@ dir="${BASH_SOURCE%/*}"
 if [[ ! -d "$dir" ]]; then dir="$PWD"; fi
 . "$dir/common.sh"
 
-cleanup
-
 sub -w 3 -l 40000 -p 40001 -p 40002 -p 40003 -p 40004 -s X
 sub -w 3 -l 40001 -p 40011 -p 40012 -p 40013 -s X
 sub -w 3 -l 40002 -p 40012 -p 40038 -s X
@@ -58,9 +56,6 @@ sub -w 3 -l 40132 -p 40135 -p 40032 -s X
 sub -w 3 -l 40135 -p 40003 -p 40004 -s X
 
 sleep 4
-
-echo "Errors"
-grep -r "ERROR" out | wc -l
 
 # Routing check
 
@@ -116,9 +111,7 @@ pub -p 40135 A B C D E F G
 
 sleep 1
 
-echo
-echo "Pubs received (expect 343)"
-grep "pub [A|B|C|D|E|F]" out/sub*.log | wc -l
+expect_pubs_received 343 A B C D E F G
 
 # Reachability check
 
@@ -126,6 +119,5 @@ pub -p 40111 X
 
 sleep 1
 
-echo
-echo "Pubs received (expect 49)"
-grep "pub X" out/sub*.log | wc -l
+assert_no_errors
+expect_pubs_received 49 X

--- a/test_scripts/loop25
+++ b/test_scripts/loop25
@@ -5,8 +5,6 @@ dir="${BASH_SOURCE%/*}"
 if [[ ! -d "$dir" ]]; then dir="$PWD"; fi
 . "$dir/common.sh"
 
-cleanup
-
 # loop
 
 sub -w 3 -l 40000 -p 40024
@@ -37,5 +35,4 @@ sub -w 1 -l 40024 -p 40023
 
 sleep 6
 
-echo "Errors"
-grep "ERROR" out/sub*.log | wc -l
+assert_no_errors

--- a/test_scripts/loop3
+++ b/test_scripts/loop3
@@ -5,13 +5,10 @@ dir="${BASH_SOURCE%/*}"
 if [[ ! -d "$dir" ]]; then dir="$PWD"; fi
 . "$dir/common.sh"
 
-cleanup
-
 sub -w 1 -l 40000 -p 40001 A
 sub -w 1 -l 40001 -p 40002 B
 sub -w 1 -l 40002 -p 40000 C
 
 sleep 4
 
-echo "Errors"
-grep -r "ERROR" out | wc -l
+assert_no_errors

--- a/test_scripts/pub100
+++ b/test_scripts/pub100
@@ -18,4 +18,5 @@ done
 
 sleep 2
 
-cleanup
+assert_no_errors
+expect_pubs_received 300 "1.1.*"

--- a/test_scripts/run
+++ b/test_scripts/run
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+TESTS="./build/test/bin/cbortest \
+       ./build/test/bin/cosetest \
+       ./build/test/bin/countvec \
+       ./build/test/bin/hist_unit \
+       ./build/test/bin/packtest \
+       ./build/test/bin/pubsub \
+       ./build/test/bin/rle_compression \
+       ./test_scripts/chain_test \
+       ./test_scripts/fanout \
+       ./test_scripts/hot_mesh \
+       ./test_scripts/loop25 \
+       ./test_scripts/loop3 \
+       ./test_scripts/pub100 \
+       ./test_scripts/simple_test \
+       ./test_scripts/tree0 \
+       ./test_scripts/tree1 \
+       ./test_scripts/tree2"
+
+DEFAULT="\e[0m"
+GREEN="\e[32m"
+RED="\e[31m"
+
+OK=0
+FAILED=0
+FAILED_TESTS=""
+
+for TEST in $TESTS; do
+    echo -e "$GREEN[ RUN      ]$DEFAULT $TEST"
+    $TEST
+    if [ $? -eq 0 ]; then
+	echo -e "$GREEN[       OK ]$DEFAULT $TEST"
+	((++OK))
+    else
+	echo -e "$RED[   FAILED ]$DEFAULT $TEST"
+	((++FAILED))
+	FAILED_TESTS="$FAILED_TESTS$RED[  FAILED  ]$DEFAULT $TEST\n"
+    fi
+done
+
+echo -e "$GREEN[==========]$DEFAULT $((OK + FAILED)) tests ran."
+if [ $OK -gt 0 ]; then
+    echo -e "$GREEN[  PASSED  ]$DEFAULT $OK tests."
+fi
+if [ $FAILED -gt 0 ]; then
+    echo -e "$RED[  FAILED  ]$DEFAULT $FAILED tests, listed below:"
+    echo -e -n "$FAILED_TESTS"
+    exit 1
+fi

--- a/test_scripts/simple_test
+++ b/test_scripts/simple_test
@@ -23,4 +23,9 @@ pub 3/2 2/3
 
 sleep 2
 
-cleanup
+assert_no_errors
+expect_pubs_received 5 1/1/1 1/1/2 1/1/3
+expect_pubs_received 3 2/1/1 1/1/4
+expect_pubs_received 2 2/1/1 3/1/1
+expect_pubs_received 4 2/1/1 1/1/4 3/1/1
+expect_pubs_received 1 3/2 2/3

--- a/test_scripts/tree0
+++ b/test_scripts/tree0
@@ -5,11 +5,17 @@ dir="${BASH_SOURCE%/*}"
 if [[ ! -d "$dir" ]]; then dir="$PWD"; fi
 . "$dir/common.sh"
 
-cleanup
-
 sub -w 1 -l 50000  T
 sub -w 1 -l 40000 -p 50000 A
 sub -w 1 -l 30000 -p 50000 B
 
-pub -w 2 -b -p 30000 A
-pub -w 2 -b -p 40000 B
+sleep 1
+
+pub -w 2 -p 30000 A
+pub -w 2 -p 40000 B
+
+sleep 2
+
+assert_no_errors
+expect_pubs_received 1 A
+expect_pubs_received 1 B

--- a/test_scripts/tree1
+++ b/test_scripts/tree1
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 #   a/b/c ----\                                   /---- 1/2/3
 #              \                                 /
@@ -13,29 +15,34 @@
 #   40002 ----/                                   \---- 60002
 #
 
-killall subscriber
+# Include common functions
+dir="${BASH_SOURCE%/*}"
+if [[ ! -d "$dir" ]]; then dir="$PWD"; fi
+. "$dir/common.sh"
 
-build/dist/bin/subscriber -l 40003 B/B &
+sub -l 40003 B/B
 sleep 1
-build/dist/bin/subscriber -l 40004 -p 40003 A/A &
+sub -l 40004 -p 40003 A/A
 sleep 1
-build/dist/bin/subscriber -l 50000 -p 40003 C/C &
-sleep 1
-
-build/dist/bin/subscriber -l 40000 -p 40004 a/b/c &
-build/dist/bin/subscriber -l 40001 -p 40004 d/e/f &
-build/dist/bin/subscriber -l 40002 -p 40004 g/h/i &
-
-build/dist/bin/subscriber -l 60000 -p 50000 1/2/3 &
-build/dist/bin/subscriber -l 60001 -p 50000 4/5/6 &
-build/dist/bin/subscriber -l 60002 -p 50000 7/8/9 &
-
+sub -l 50000 -p 40003 C/C
 sleep 1
 
-build/dist/bin/publisher -p 40003 a/b/c 4/5/6 -m "---- published a/b/c 4/5/6"
-build/dist/bin/publisher -p 40004 d/e/f -m "---- published d/e/f"
-build/dist/bin/publisher -p 40000 1/2/3 -m "---- published 1/2/3"
-build/dist/bin/publisher -p 50000 g/h/i -m "---- published g/h/i"
+sub -l 40000 -p 40004 a/b/c
+sub -l 40001 -p 40004 d/e/f
+sub -l 40002 -p 40004 g/h/i
+
+sub -l 60000 -p 50000 1/2/3
+sub -l 60001 -p 50000 4/5/6
+sub -l 60002 -p 50000 7/8/9
+
+sleep 1
+
+pub -p 40003 a/b/c 4/5/6
+pub -p 40004 d/e/f
+pub -p 40000 1/2/3
+pub -p 50000 g/h/i
+
+sleep 1
 
 # Now some retained pubs
 #
@@ -46,12 +53,12 @@ build/dist/bin/publisher -p 50000 g/h/i -m "---- published g/h/i"
 #   g/h/i ----/                                   \---- 7/8/9
 #
 #
-build/dist/bin/subscriber -p 60000 "+/#" &
+sub -p 60000 "+/#"
 sleep 1
 
-build/dist/bin/publisher -t 20 -p 40000 X/X -m "---- published X/X"
-build/dist/bin/publisher -t 20 -p 60000 Y/Y -m "published Y/Y"
-build/dist/bin/publisher -t 20 -p 40004 Z/Z -m "published Z/Z"
+pub -t 20 -p 40000 X/X
+pub -t 20 -p 60000 Y/Y
+pub -t 20 -p 40004 Z/Z
 
 sleep 1
 
@@ -63,4 +70,13 @@ sleep 1
 #                               |
 #
 
-build/dist/bin/subscriber -p 40003 "+/#" &
+sub -p 40003 "+/#"
+
+assert_no_errors
+expect_pubs_received 2 a/b/c 4/5/6
+expect_pubs_received 1 d/e/f
+expect_pubs_received 1 1/2/3
+expect_pubs_received 1 g/h/i
+expect_pubs_received 2 X/X
+expect_pubs_received 2 Y/Y
+expect_pubs_received 2 Z/Z

--- a/test_scripts/tree2
+++ b/test_scripts/tree2
@@ -16,8 +16,6 @@ if [[ ! -d "$dir" ]]; then dir="$PWD"; fi
 #
 #
 
-cleanup
-
 sub -l 40000 E
 sleep 1
 


### PR DESCRIPTION
- Add API to expose subsRate needed by subscriber and publisher
  examples used in test scripts.
- Add assert_no_errors and expect_pubs_received checks to common test
  script code.
- Replace assert macro used in tests with one that works in both
  release and debug builds.
- Install trap to clean up after test scripts instead of expecting
  script to  do it correctly.

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>